### PR TITLE
remove X Server dependency for GTK display

### DIFF
--- a/lucid3/lucid_core.py
+++ b/lucid3/lucid_core.py
@@ -40,6 +40,8 @@ import shutil
 import tempfile
 import scipy.misc
 import numpy as np
+import matplotlib as mpl
+mpl.use('Agg')
 import matplotlib.pyplot as plt
 
 # Find out if we are using OpenCV version 3:


### PR DESCRIPTION
While "import matplotlib.pyplot as plt", it comlained "RuntimeError: could not open display" because matplotlib failed to connect to any X server for its GTK display. To solve this, run matplotlib.use() to specify a different display back-end.


